### PR TITLE
If limit is above MaxPageSize, expect MaxPageSize

### DIFF
--- a/controller/paging.go
+++ b/controller/paging.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	pageSizeDefault = 20
-	pageSizeMax     = 500
+	PageSizeMax     = 500
 )
 
 func computePagingLimits(offsetParam *string, limitParam *int) (offset int, limit int) {
@@ -41,8 +41,8 @@ func computePagingLimits(offsetParam *string, limitParam *int) (offset int, limi
 
 	if limit <= 0 {
 		limit = pageSizeDefault
-	} else if limit > pageSizeMax {
-		limit = pageSizeMax
+	} else if limit > PageSizeMax {
+		limit = PageSizeMax
 	}
 	return offset, limit
 }

--- a/controller/workitem_blackbox_test.go
+++ b/controller/workitem_blackbox_test.go
@@ -198,8 +198,8 @@ func (s *WorkItemSuite) TestPagingDefaultAndMaxSize() {
 	limit = 1000
 	_, result = test.ListWorkitemsOK(s.T(), context.Background(), nil, s.workitemsCtrl, space.SystemSpace, nil, nil, nil, nil, nil, nil, nil, nil, &limit, &offset, nil, nil, nil)
 	// then
-	if !strings.Contains(*result.Links.First, "page[limit]=500") {
-		assert.Fail(s.T(), "Limit is more than max", "Expected limit to be %d, got %v", 1000, *result.Links.First)
+	if !strings.Contains(*result.Links.First, fmt.Sprintf("page[limit]=%d", PageSizeMax)) {
+		assert.Fail(s.T(), "Limit is more than max", "Expected limit to be %d, got %v", PageSizeMax, *result.Links.First)
 	}
 	// when
 	limit = 50


### PR DESCRIPTION
When you ask for a 1000 work items, the system shall only return whatever the maximum page limit is. This change makes use of the constant for the max page size as pointed out by @stevengutz 
 here: https://github.com/fabric8-services/fabric8-wit/pull/2166#discussion_r202308051

Improvement for https://github.com/fabric8-services/fabric8-wit/pull/2166